### PR TITLE
Re-enabling filetype after vundle section : ensuring filetype on after vundles

### DIFF
--- a/articles/tutorials/vim.md
+++ b/articles/tutorials/vim.md
@@ -59,6 +59,7 @@ set runtimepath+=~/.vim/bundle/vundle/
 call vundle#rc()
 Bundle 'gmarik/vundle'
 Bundle 'VimClojure'
+filetype on
 ```
 
 Step 2 : Run this in the terminal:


### PR DESCRIPTION
Just to prevent vim newbies from getting confused on why no syntax highlighting is happening after pasting these lines into their `~/.vimrc`.
