### PR TITLE
Fix definition of S-Expression

### DIFF
--- a/articles/language/glossary.md
+++ b/articles/language/glossary.md
@@ -325,7 +325,7 @@ called like `(my-func 1 2 3 4 5)`, then 3, 4, & 5 are the "rest args".
 ### s-expression
 
 Short for Symbolic Expression. A S-Expression is a data structure able
-to represent both simple datastructes such as atoms, or complex data
+to represent both simple datastructes such as literals, or complex data
 structures such as nested expressions. Due to their versatile nature,
 S-Expressions are able to represent both data in Clojure, as well as
 the Clojure code itself, allowing Clojure to be a


### PR DESCRIPTION
Realized after reading the definition again, that I wanted to define in regards to literals and complex data structures instead of atoms and complex data structures.
