### PR TITLE
Fixed typo for map in Introduction

### DIFF
--- a/articles/tutorials/introduction.md
+++ b/articles/tutorials/introduction.md
@@ -574,7 +574,7 @@ Getting values from data structures:
 ;; Same as vectors, but can't index.
 
 ;; Maps
-(def m {:a 1 :b 2}
+(def m {:a 1 :b 2})
 (get m :a)            ; ⇒ 1
 (m :a)                ; ⇒ 1       (same)
 (:a m)                ; ⇒ 1       (same!)


### PR DESCRIPTION
Under Functions For Working With Data Structures

``` clojure
(def m {:a 1 :b 2}
```

should have been

``` clojure
(def m {:a 1 :b 2})
```
