### PR TITLE
add mpenet/alia to lib dir

### DIFF
--- a/articles/ecosystem/libraries_directory.md
+++ b/articles/ecosystem/libraries_directory.md
@@ -255,6 +255,8 @@ For more comprehensive overview of the Clojure library ecosystem, please see [Cl
 
   * [clj-hector](https://github.com/pingles/clj-hector) ([at clojars](https://clojars.org/org.clojars.paul/clj-hector)): A simple Clojure client for Cassandra that wraps Hector
 
+  * [Alia](https://github.com/mpenet/alia) ([at clojars](https://clojars.org/cc.qbits/alia)): Cassandra CQL3 client for Clojure, [datastax/java-driver](https://github.com/datastax/java-driver) wrapper
+
 ### Amazon DynamoDB
 
   * [Rotary](https://github.com/weavejester/rotary) ([at clojars](https://clojars.org/rotary))


### PR DESCRIPTION
I believe this is worth ading there, this is fairly complete, documented, used by a few people already (production ready, even though the underlying java driver is quite young) and relies on strong fondations.
