### PR TITLE
Added section on templating libraries for web development

### DIFF
--- a/articles/ecosystem/libraries_directory.md
+++ b/articles/ecosystem/libraries_directory.md
@@ -161,6 +161,8 @@ For more comprehensive overview of the Clojure library ecosystem, please see [Cl
 ### HTML Generation
 
   * [hiccup](https://clojars.org/hiccup): Generates HTML from Clojure data structures.
+  
+  * [Stencil](https://github.com/davidsantiago/stencil): Implements the Mustache templating language.
 
   * [markdown-clj](https://clojars.org/markdown-clj): Clojure based Markdown parsers for both Clojure and ClojureScript.
 

--- a/articles/ecosystem/web_development.md
+++ b/articles/ecosystem/web_development.md
@@ -53,6 +53,63 @@ libraries.
 
 
 
+## Templating Libraries
+
+Clojure has many options for building HTML.
+
+
+### Hiccup
+
+[Hiccup](https://github.com/weavejester/hiccup) represents HTML as
+Clojure data structures, allowing you to create and manipulate your
+HTML easily.
+
+[Tinsel](https://github.com/davidsantiago/tinsel) is a library that
+extends Hiccup with selectors and transformers, so that you can write
+a template separate from the insertion of your data into the template.
+
+
+### Mustache
+
+[Clostache](https://github.com/fhd/clostache) implements the
+[Mustache](http://mustache.github.com/) templating language for
+Clojure.
+
+[Stencil](https://github.com/davidsantiago/stencil) is another
+implementation of Mustache.
+
+
+### Fleet
+
+[Fleet](https://github.com/Flamefork/fleet) embeds Clojure inside HTML
+templates, much like Java's JSPs, or Ruby's ERb.
+
+
+### Clabango
+
+[Clabango](https://github.com/danlarkin/clabango) is modeled after the
+[Django templating system](https://docs.djangoproject.com/en/1.4/topics/templates/). It
+embeds special tags and filters inside HTML templates to insert and
+manipulate data.
+
+
+### Enlive and Laser
+
+[Enlive](https://github.com/cgrand/enlive) and
+[Laser](https://github.com/Raynes/laser) are similar libraries. They
+both manipulate plain HTML, and can be used for screen scraping as
+well as templating. They work with HTML templates with no special
+embedded tags or code. They use selector functions to find pieces of
+HTML and transformation function to change the HTML into the way you
+want.
+
+See the
+[Laser guide](https://github.com/Raynes/laser/blob/master/docs/guide.md)
+to see if this style of templating works for you. It is powerful, but
+different from most other languages' templating libraries.
+
+
+
 ## See Also
 
   * the [web development section of the library
@@ -66,4 +123,5 @@ libraries.
 
 ## Contributors
 
-John Gabriele
+* John Gabriele
+* Clinton Dreisbach


### PR DESCRIPTION
The overview of web development looks like it could use some work. I recently tried many different templating systems for Clojure, so I thought I'd add a section on them. I tried to keep it very neutral.
