### PR TITLE
Force dependency on Redcarpet master.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "http://rubygems.org"
 
 gem "jekyll", "~> 1.2.1"
-gem "redcarpet"
+gem "redcarpet", git: 'git@github.com:tjg/redcarpet.git', branch: 'master'
 # with Ruby 2.0 on OS X, you may need to install
 # it manually with --with-iconv-dir:
 #

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: git@github.com:tjg/redcarpet.git
+  revision: 233e466bb2d93a91f4a4494a14679efbdf05a433
+  branch: master
+  specs:
+    redcarpet (3.0.0)
+
 GEM
   remote: http://rubygems.org/
   specs:
@@ -18,7 +25,7 @@ GEM
       liquid (~> 2.5.2)
       maruku (~> 0.5)
       pygments.rb (~> 0.5.0)
-      redcarpet (~> 2.3.0)
+      redcarpet
       safe_yaml (~> 0.7.0)
     liquid (2.5.3)
     maruku (0.7.0)
@@ -26,7 +33,6 @@ GEM
     pygments.rb (0.5.2)
       posix-spawn (~> 0.3.6)
       yajl-ruby (~> 1.1.0)
-    redcarpet (2.3.0)
     safe_yaml (0.7.1)
     yajl-ruby (1.1.0)
 
@@ -36,4 +42,4 @@ PLATFORMS
 DEPENDENCIES
   iconv
   jekyll (~> 1.2.1)
-  redcarpet
+  redcarpet!


### PR DESCRIPTION
This fixes broken links, solving https://github.com/clojuredocs/guides/issues/143.

(It forces dependency on Redcarpet's master branch, to gain `with_toc_data` improvements.)

**Security note:** This points at my personal Redcarpet fork, to guard against GitHub's security hole where attackers can change a pull request right before target accepts it. However, _I may be an attacker_. So clojuredocs should probably reject this pull request, create its own Redcarpet fork, and point the gemfiles to it.

Verification:
- [x] `diff -r _site _site.old > diff.txt`
- [x] Verify diff with https://gist.github.com/tjg/b7c26738d279c2078604
