### PR TITLE
The navigation bar overlaps headers when using anchors

### DIFF
--- a/assets/stylesheets/bootstrap-docs.css
+++ b/assets/stylesheets/bootstrap-docs.css
@@ -497,7 +497,7 @@ body {
 }
 
 /* Janky fix for preventing navbar from overlapping */
-h1[id] {
+h1[id], h2[id] {
   padding-top: 80px;
   margin-top: -45px;
 }


### PR DESCRIPTION
For example, http://clojure-doc.org/articles/tutorials/vim_fireplace.html#installing-fireplace.vim. Because the navi bar is implemented so that it overlaps the content, the header for the anchor won't be visible.

The expected behavior would be something like this: 
![clojure with vim and fireplace vim clojure documentation clojure docs 2013-12-25 17-23-25](https://f.cloud.github.com/assets/11027/1808791/80d9fd78-6d78-11e3-971e-cf59263f9eb9.png)
