### PR TITLE
Hide menu if devise width <990px

### DIFF
--- a/assets/stylesheets/bootstrap-docs.css
+++ b/assets/stylesheets/bootstrap-docs.css
@@ -1091,3 +1091,8 @@ h1[id], h2[id] {
 #toc {
   width: 275px;
 }
+@media screen and (max-width: 990px) {
+    #toc {
+        display: none;
+    }
+}


### PR DESCRIPTION
What about hiding this menu if screen width is less 990px ?
As for me it's comfortable and add opportunity to read this guides on ipad or iphone 

related #162
