### PR TITLE
Run the $SHELL with TERM=vt100 to avoid problems with zsh

### DIFF
--- a/articles/tutorials/emacs.md
+++ b/articles/tutorials/emacs.md
@@ -61,7 +61,7 @@ issues when launching Emacs from the GUI on OS X
 ```cl
 ;; fix the PATH variable
 (defun set-exec-path-from-shell-PATH ()
-  (let ((path-from-shell (shell-command-to-string "$SHELL -i -c 'echo $PATH'")))
+  (let ((path-from-shell (shell-command-to-string "TERM=vt100 $SHELL -i -c 'echo $PATH'")))
     (setenv "PATH" path-from-shell)
     (setq exec-path (split-string path-from-shell path-separator))))
 


### PR DESCRIPTION
Without setting the `$TERM` and in case `$SHELL` happens to be zsh the `exec-path` becomes the following when the script is run at init time from `init.el`:

```
("tput" " No value for $TERM and no -T specified
tput" " No value for $TERM and no -T specified
tput" " No value for $TERM and no -T specified
tput" " No value for $TERM and no -T specified
tput" " No value for $TERM and no -T specified
tput" " No value for $TERM and no -T specified
tput" " No value for $TERM and no -T specified
tput" " No value for $TERM and no -T specified
tput" " No value for $TERM and no -T specified
tput" " No value for $TERM and no -T specified
tput" " No value for $TERM and no -T specified
tput" " No value for $TERM and no -T specified
tput" " No value for $TERM and no -T specified
tput" " No value for $TERM and no -T specified
tput" " No value for $TERM and no -T specified
tput" " No value for $TERM and no -T specified
tput" " No value for $TERM and no -T specified
tput" " No value for $TERM and no -T specified
tput" " No value for $TERM and no -T specified
tput" " No value for $TERM and no -T specified
/usr/local/bin" "/usr/local/sbin" "/bin" "/usr/sbin" "/sbin" "/usr/bin" "/usr/X11/bin" "/usr/local/mysql/bin" "/Users/rauhahe/bin" "/usr/local/share/npm/bin
")
```

The version with `TERM=vt100` works fine with bash as well.

After init the original function works even with zsh, but at init time it needs the explicitly set `TERM` variable.
