### PR TITLE
Use proper Cocoa flag for Homebrew in the Emacs tutorial.

### DIFF
--- a/articles/tutorials/emacs.md
+++ b/articles/tutorials/emacs.md
@@ -37,7 +37,7 @@ correctly.
 Once brew is installed, you can install Emacs 24 using:
 
 ```bash
-$ brew install emacs --cocoa --srgb
+$ brew install emacs --with-cocoa --srgb
 $ brew linkapps Emacs
 ```
 


### PR DESCRIPTION
Looks like the `--cocoa` option in the Homebrew install command [has been changed](https://github.com/Homebrew/homebrew/blob/7d42727b09b1a1ef5f4830815b2f5b3c8bb669f0/Library/Formula/emacs.rb#L29) to `--with-cocoa`.