### PR TITLE
Remove `--srgb` option when installing emacs via `brew`

### DIFF
--- a/articles/tutorials/emacs.md
+++ b/articles/tutorials/emacs.md
@@ -37,7 +37,7 @@ correctly.
 Once brew is installed, you can install Emacs 24 using:
 
 ```bash
-$ brew install emacs --with-cocoa --srgb
+$ brew install emacs --with-cocoa
 $ brew linkapps Emacs
 ```
 


### PR DESCRIPTION
Just a minor docs update.  This option is no longer needed as this is incorporated in the emacs build upstream.  The relevant commit for this is [here](https://github.com/Homebrew/homebrew/commit/e465cb17e02111bb247d9f7c2eb2b8a26b16de3a).