### PR TITLE
articles/tutorials/emacs.md: Fix code blocks.

### DIFF
--- a/articles/tutorials/emacs.md
+++ b/articles/tutorials/emacs.md
@@ -128,6 +128,7 @@ the community package host. Add this code to your config in
 `~/.emacs.d/init.el` to tell Emacs to look there:
 
 For the stable repository:
+
 ```cl
 (require 'package)
 (add-to-list 'package-archives
@@ -136,6 +137,7 @@ For the stable repository:
 ```
 
 For the latest packages:
+
 ```cl
 (require 'package)
 (add-to-list 'package-archives


### PR DESCRIPTION
See <http://clojure-doc.org/articles/tutorials/emacs.html>.  They don't get parsed right when there's no empty line before the \`\`\`.