### PR TITLE
Introduction: declare do-it

### DIFF
--- a/articles/tutorials/introduction.md
+++ b/articles/tutorials/introduction.md
@@ -1020,6 +1020,8 @@ know about a function's existence, use `declare`:
 ``` clojure
 ;; pseudocode
 
+(declare do-it)
+
 (do-it)
 
 (declare my-func-a)


### PR DESCRIPTION
This example shows the necessity and usage of `declare` but forgot to declare `do-it` itself, so the code is still broken. This patch fixes that.