### PR TITLE
Fix documentation for contains? in core guide.

### DIFF
--- a/articles/language/collections_and_sequences.md
+++ b/articles/language/collections_and_sequences.md
@@ -634,9 +634,9 @@ Do not confuse `empty?` with `empty`. This can be a source of great confusion:
 (contains? ["John" "Mary" "Paul"] "Paul")
 ;; ⇒ false
 
-;; lists always return false. Contain won't traverse a collection for a result.
+;; lists are not supported. contains? won't traverse a collection for a result.
 (contains? '(1 2 3) 0)
-;; ⇒ false
+;; ⇒ java.lang.IllegalArgumentException: contains? not supported on type: clojure.lang.PersistentList
 ```
 
 ### some

--- a/articles/language/core_overview.md
+++ b/articles/language/core_overview.md
@@ -888,9 +888,10 @@ key as an index. `contains` will always return false for lists.
 (contains? ["John" "Mary" "Paul"] "Paul")
 ;; ⇒ false
 
-;; lists always return false. Contain won't traverse a collection for a result.
+;; lists are not supported. contains? won't traverse a collection for a result.
 (contains? '(1 2 3) 0)
-;; ⇒ false
+;; ⇒ java.lang.IllegalArgumentException: contains? not supported on type: clojure.lang.PersistentList
+
 ```
 
 <a id="keys_desc"></a>


### PR DESCRIPTION
contains? doesn't support lists.
Fixed in core.guide, section "Items in a Collection or Sequence".