### PR TITLE
Replace SLIME with CIDER

### DIFF
--- a/articles/content.md
+++ b/articles/content.md
@@ -47,7 +47,7 @@ A brief introduction to Counterclockwise, a Clojure plugin for Eclipse.
 
 ### [Emacs for Clojure Development](/articles/tutorials/emacs.html)
 
-A brief introduction to Emacs, Clojure mode, SLIME and Clojure development workflow with Emacs.
+A brief introduction to Emacs, Clojure mode, CIDER and Clojure development workflow with Emacs.
 
 ### [Vim for Clojure Development](/articles/tutorials/vim_fireplace.html)
 


### PR DESCRIPTION
Hello,
 The [Essentials - Emacs](http://clojure-doc.org/articles/tutorials/emacs.html) document no longer refers to SLIME nor SWANK. So the subtitle will be sweeter if we drop SLIME for CIDER. Thank you. Good day.