### PR TITLE
Fix #249 by linking to repl.it instead

### DIFF
--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -57,7 +57,7 @@
               <a href='https://github.com/clojuredocs/guides'>Source on GitHub</a>
             </li>
             <li>
-              <a href='http://tryclj.com'>Try Clojure</a>
+              <a href='https://repl.it/languages/clojure'>Try Clojure</a>
             </li>
           </ul>
         </nav>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -57,7 +57,7 @@
               <a href='https://github.com/clojuredocs/guides'>Source on GitHub</a>
             </li>
             <li>
-              <a href='http://tryclj.com'>Try Clojure</a>
+              <a href='https://repl.it/languages/clojure'>Try Clojure</a>
             </li>
           </ul>
         </nav>


### PR DESCRIPTION
repl.it seems closest to what tryclj.com used to be.