### PR TITLE
Remove `do`

### DIFF
--- a/articles/language/macros.md
+++ b/articles/language/macros.md
@@ -229,7 +229,7 @@ Compare this with what the macro expands to when the unquote is removed:
 (defmacro unless
   [condition & forms]
   `(if (not condition)
-     (do ~@forms)))
+     ~@forms))
 
 (macroexpand-1 '(unless (= 1 2) true false))
 ;= (if (clojure.core/not user/condition) (do true false))

--- a/articles/language/macros.md
+++ b/articles/language/macros.md
@@ -232,7 +232,7 @@ Compare this with what the macro expands to when the unquote is removed:
      ~@forms))
 
 (macroexpand-1 '(unless (= 1 2) true false))
-;= (if (clojure.core/not user/condition) (do true false))
+;= (if (clojure.core/not user/condition) true false)
 ```
 
 ### Implementation Details


### PR DESCRIPTION
In one of the code blocks of the definition of `unless` was a erroneous `do` block that changes the semantic of  `unless`.